### PR TITLE
Allow to pass Joi.ref to phoneNumber.region()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -48,16 +48,19 @@ module.exports = (joi) => {
 
             const defaultRegion = requiredRegion || this._flags.phoneNumberDefaultRegion || null;
 
+            const isRef = joi.isRef(defaultRegion);
+            const region = isRef ? defaultRegion(state.reference || state.parent, options) : defaultRegion;
+
             try {
-                parsedNumber = phoneNumberUtil.parse(value, defaultRegion);
+                parsedNumber = phoneNumberUtil.parse(value, region);
             } catch (err) {
                 return this.createError('phoneNumber.base', { value }, state, options);
             }
 
 
             if (requiredRegion) {
-                if (!phoneNumberUtil.isValidNumberForRegion(parsedNumber, requiredRegion)) {
-                    return this.createError('phoneNumber.region', { value, region: requiredRegion }, state, options);
+                if (!phoneNumberUtil.isValidNumberForRegion(parsedNumber, region)) {
+                    return this.createError('phoneNumber.region', { value, region: region }, state, options);
                 }
             } else if (!phoneNumberUtil.isValidNumber(parsedNumber)) {
                 return this.createError('phoneNumber.base', { value }, state, options);
@@ -110,7 +113,9 @@ module.exports = (joi) => {
             {
                 name: 'region',
                 params: {
-                    region: joi.string().uppercase().only(Object.keys(PhoneNumber.metadata.countryToMetadata)).required(),
+                    region: joi.alternatives([
+                        joi.string().uppercase().only(Object.keys(PhoneNumber.metadata.countryToMetadata)),
+                        joi.func().ref()]).required()
                 },
                 description(params) {
                     return `Phone number should be of region ${params.region}`;

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,12 +26,19 @@ const formatToString = (format) => findKey(PNF, format);
 
 
 module.exports = (joi) => {
+    const regionValidation = joi
+        .string()
+        .uppercase()
+        .only(Object.keys(PhoneNumber.metadata.countryToMetadata));
+
     return {
         base: joi.string(),
         name: 'phoneNumber',
         language: {
             base: 'must be a valid phone number',
             region: 'must be number of region {{region}}',
+            emptyFieldRef: 'region reference "{{ref}}" must point to a non empty field',
+            illegalRefRegion: `region reference "{{ref}}" must be one of [${Object.keys(PhoneNumber.metadata.countryToMetadata).join(', ')}]`,
             type: 'must be a {{type}} phone number',
             format: 'must be formatted in {{format}} format',
         },
@@ -50,6 +57,17 @@ module.exports = (joi) => {
 
             const isRef = joi.isRef(defaultRegion);
             const region = isRef ? defaultRegion(state.reference || state.parent, options) : defaultRegion;
+
+            if (isRef) {
+                if (!region) {
+                    return this.createError('phoneNumber.emptyFieldRef', { ref: defaultRegion.key }, state, options);                    
+                }
+
+                const regionValidationResult = regionValidation.validate(region);
+                if (regionValidationResult.error) {
+                    return this.createError('phoneNumber.illegalRefRegion', { ref: defaultRegion.key }, state, options);
+                }
+            }
 
             try {
                 parsedNumber = phoneNumberUtil.parse(value, region);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "joi-phone-number-extensions",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/spec/phoneNumber.spec.js
+++ b/spec/phoneNumber.spec.js
@@ -88,6 +88,22 @@ describe('phoneNumber', () => {
             });
             expect(schema).toPassValidation({ phone: '+1 541-754-3010', region: 'US'});
         });
+
+        it('should fail validation for Joi.ref with illegal value', () => {
+            const schema = Joi.object().keys({
+                phone: Joi.phoneNumber().region(Joi.ref('region')),
+                region: Joi.string()
+            });
+            expect(schema).toFailValidation({ phone: '+1 541-754-3010', region: 'USA'}, /"phone" region reference "region" must be one of \[.*UG, US, UY, UZ.*]/);
+        });
+
+        it('should fail validation for Joi.ref pointing to an empty field', () => {
+            const schema = Joi.object().keys({
+                phone: Joi.phoneNumber().region(Joi.ref('NONFIELD')),
+                region: Joi.string()
+            });
+            expect(schema).toFailValidation({ phone: '+1 541-754-3010'}, /"phone" region reference "NONFIELD" must point to a non empty field/);
+        });
     });
 
     describe('type', () => {

--- a/spec/phoneNumber.spec.js
+++ b/spec/phoneNumber.spec.js
@@ -80,6 +80,14 @@ describe('phoneNumber', () => {
                     .toFailValidation('035555555', '"value" must be number of region US');
             });
         });
+
+        it('should accept value via Joi.ref and pass validation', () => {
+            const schema = Joi.object().keys({
+                phone: Joi.phoneNumber().region(Joi.ref('region')),
+                region: Joi.string()
+            });
+            expect(schema).toPassValidation({ phone: '+1 541-754-3010', region: 'US'});
+        });
     });
 
     describe('type', () => {


### PR DESCRIPTION
This small change allows to pass Joi references to region()

For example:

```javascript
const schema = Joi.object().keys({
  phone: Joi.phoneNumber().region(Joi.ref('origin')).format('E164'),
  origin: Joi.string(),
});

const obj = { phone: '494322456', origin: 'BE' };

schema.validate(obj);
```

I've added a matching test case to ensure this scenario is checked as well.

Cheers,
-saar